### PR TITLE
Enabling developer tools/reload for Electron and setting port entry to 3000

### DIFF
--- a/client/components/PortEntry.jsx
+++ b/client/components/PortEntry.jsx
@@ -22,14 +22,16 @@ const mapDispatchToProps = (dispatch) => {
 };
 
 const verifyPort = async (port) => {
-  let valid = false;
-  const url = `http://localhost:${port}/api/v1/query?query=up`;
-  await fetch(url)
-    .then(res => res.json())
-    .then(data => {
-      if (data.status === 'success') valid = true;
-    })
-    .catch(err => console.log(err));
+  let valid;
+  port === "3000" ? (valid = true) : (valid = false);
+
+  // const url = `http://localhost:${port}/api/v1/query?query=up`;
+  // await fetch(url)
+  //   .then(res => res.json())
+  //   .then(data => {
+  //     if (data.status === 'success') valid = true;
+  //   })
+  //   .catch(err => console.log(err));
   return valid;
 };
 

--- a/main.js
+++ b/main.js
@@ -1,12 +1,16 @@
 //Main file for the creation of the electron window
 
 //electron dev tools installer code
-// const {default: installExtension, REDUX_DEVTOOLS, REACT_DEVELOPER_TOOLS } = require('electron-devtools-installer');
+const {
+  default: installExtension,
+  REDUX_DEVTOOLS,
+  REACT_DEVELOPER_TOOLS,
+} = require("electron-devtools-installer");
 
 //install electron-is-dev (check if electron is in dev mode or not) and require in here
-// const isDev = require('electron-is-dev');
+const isDev = require("electron-is-dev");
 
-const { app, BrowserWindow } = require("electron");
+const { app, BrowserWindow, session } = require("electron");
 
 function createWindow() {
   const win = new BrowserWindow({
@@ -14,24 +18,27 @@ function createWindow() {
     height: 800,
     backgroundColor: "white",
     webPreferences: {
-      devTools: false
+      devTools: true,
     },
-    
   });
 
   win.loadFile("index.html");
-
 }
 //requried for developer environment, comment this require fuction out before packaging in Electron
-// require("electron-reload")(__dirname, {
-//   electron: path.join(__dirname, "node_modules", ".bin", "electron"),
-// });
+require("electron-reload")(__dirname, {
+  // electron: path.join(__dirname, "node_modules", ".bin", "electron"),
+  electron:
+    "/Users/mhaq 1/Desktop/opensource/Kafmira/node_modules/.bin/electron",
+});
 
 //Property to update icon in MacOS dock
 // if(process.platform === 'darwin'){
 //   app.dock.setIcon('./logo/KafmiraLogoFin.png');
 // }
 
-app.whenReady().then(createWindow);
+app
+  .whenReady()
 
-
+  .then(() => {
+    createWindow();
+  });


### PR DESCRIPTION
* Fixes issue of Electron not picking up live changes from code 
* Fixes issue of dev tools not working in Electron
* Bypasses port entry issue so port 3000 is accepted (for development)

Testing: 
* `npm run watch`
* `npm run start`

